### PR TITLE
Remove redundant coverage settings from pyproject.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ A clean and production-ready Django project template that supports both local de
 - Code quality tools including `ruff` for linting Python code and `djlint` for linting and formatting Jinja2 templates
 - Authentication with `django-allauth` (including MFA support)
 - Pre-configured logging with separate log files for Django, Gunicorn, and Nginx
+- Test coverage measurement with `coverage` and `.coveragerc` for precise code coverage reports
 
 ## Limitations
 
@@ -54,6 +55,8 @@ project_directory/
 ├── .gitignore                 # Git ignore rules
 ├── .dockerignore              # Docker ignore rules
 ├── .djlintrc                  # Configuration for djlint (Jinja2 linter/formatter)
+├── .coveragerc                # Configuration for coverage (test coverage measurement)
+├── pytest.ini                 # Configuration for pytest
 ├── docker-compose.yml         # Docker Compose configuration
 ├── conf/                      # Configuration files
 │   ├── env_vars/              # Environment variables
@@ -117,7 +120,7 @@ project_directory/
     └── templates/             # Django templates (empty by default)
 ```
 
-**Note**: The `.djlintrc` file is now included in the project root to configure `djlint` for linting and formatting Jinja2 templates.
+**Note**: The `.djlintrc` file is included in the project root to configure `djlint` for linting and formatting Jinja2 templates, and `.coveragerc` configures `coverage` for test coverage reporting.
 
 ## Prerequisites
 
@@ -423,6 +426,11 @@ This intentional split allows flexibility: local development can skip Docker bui
 - **Redis Configuration**: The provided `conf/redis/redis.conf` is a basic template for development. Before production, adjust settings like `maxmemory`, uncomment and set `requirepass` for security, and review other parameters based on your workload.
 - **django-allauth**: Requires `allauth.account.middleware.AccountMiddleware` in `MIDDLEWARE` (included in `base.py`). Configure additional settings (e.g., social auth) in `settings/production.py` if needed.
 - **Monitoring**: Integrate Sentry (included in `production.in`) by setting `SENTRY_DSN` in `production.env`.
+- **Test Coverage**: Use `coverage` to measure test coverage and ensure high code quality. Run tests with coverage and generate a detailed report:
+  ```zsh
+  coverage run <project_name>/manage.py test config.tests
+  coverage report -m
+  ```
 
 ## Troubleshooting
 

--- a/install.sh
+++ b/install.sh
@@ -237,15 +237,6 @@ addopts = "--ds=${project_name}.config.settings.test --import-mode=importlib"
 python_files = ["tests.py", "test_*.py"]
 DJANGO_SETTINGS_MODULE = "${project_name}.config.settings.test"  # Test settings
 
-[tool.coverage.run]
-source = ["${project_name}"]  # Coverage for the project directory
-omit = [
-    "${project_name}/**/migrations/*",      # Exclude migrations
-    "${project_name}/**/tests/*",           # Exclude tests
-    "${project_name}/config/settings/*"     # Exclude settings
-]
-plugins = ["django_coverage_plugin"]
-
 [tool.mypy]
 python_version = "3.12"
 check_untyped_defs = true

--- a/install.sh
+++ b/install.sh
@@ -298,9 +298,43 @@ install -m 644 /dev/null "${project_path}/pytest.ini"
 cat > "${project_path}/pytest.ini" << EOL
 [pytest]
 DJANGO_SETTINGS_MODULE = config.settings.local
-python_files = tests.py test_*.py *_tests.py
-pythonpath = .
-addopts = --ds=config.settings.local --strict-markers
+python_files = tests.py test_*.py
+addopts = --strict-markers --tb=short --capture=no
+log_level = WARNING
+EOL
+
+# Create .coveragerc for coverage configuration
+echo -e "\e[38;5;72m[INFO]\e[0m Creating .coveragerc for coverage configuration..."
+install -m 644 /dev/null "${project_path}/.coveragerc"
+cat > "${project_path}/.coveragerc" << EOL
+[run]
+# Only measure files under the "${project_name}" package
+source = ${project_name}
+
+# Exclude these patterns from the coverage measurement
+omit =
+    ${project_name}/*/tests/*
+    ${project_name}/*/migrations/*
+    ${project_name}/manage.py
+    ${project_name}/config/wsgi.py
+    ${project_name}/config/asgi.py
+    ${project_name}/config/settings/*
+    ${project_name}/jinja2/*
+    ${project_name}/static/*
+    ${project_name}/staticfiles/*
+    ${project_name}/templates/*
+
+# Measure branch coverage (which lines executed vs. logical branches)
+branch = True
+
+[report]
+# Show which lines are missing
+show_missing = True
+
+# Do not count these lines (e.g. pragmas or __main__ guard)
+exclude_lines =
+    pragma: no cover
+    if __name__ == '__main__':
 EOL
 
 # Create Redis configuration
@@ -940,18 +974,28 @@ from django.template.context_processors import csrf
 from django.templatetags.static import static
 from django.urls import reverse
 
-from jinja2 import Environment
+from jinja2 import Environment, select_autoescape
 
 
 def environment(**options):
-    env = Environment(**options)
+    """Configure and return a Jinja2 environment."""
+    options.pop('autoescape', None)
+    env = Environment(
+        autoescape=select_autoescape(
+            enabled_extensions=('html', 'j2'),
+            default_for_string=True,
+        ),
+        **options,
+    )
+
     env.globals.update(
         {
             'static': static,
             'url': reverse,
             'csrf_token': csrf,
-        },
+        }
     )
+
     return env
 EOF
 
@@ -1211,7 +1255,7 @@ LOGGING = {
     },
     'root': {
         'handlers': ['console', 'file'],
-        'level': 'DEBUG',
+        'level': 'INFO',
     },
     'loggers': {
         'django': {
@@ -1227,6 +1271,16 @@ LOGGING = {
         'django.utils.autoreload': {
             'handlers': ['console'],
             'level': 'WARNING',
+            'propagate': False,
+        },
+        'faker': {
+            'handlers': ['console'],
+            'level': 'WARNING',
+            'propagate': False,
+        },
+        'django.server': {
+            'handlers': ['console'],
+            'level': 'INFO',
             'propagate': False,
         },
     },
@@ -1769,7 +1823,7 @@ if [ "$environment" = "local" ]; then
         echo -e "\e[38;5;196m[ERROR]\e[0m Failed to initialize Git repository."
         exit 1
     fi
-    git add .gitignore .dockerignore .pre-commit-config.yaml .djlintrc pyproject.toml docker-compose.yml "${project_name}/"
+    git add .gitignore .dockerignore .pre-commit-config.yaml .djlintrc pyproject.toml docker-compose.yml .coveragerc pytest.ini docker/ "${project_name}/"
     git commit -m "chore: init project structure"
     if [ $? -ne 0 ]; then
         echo -e "\e[38;5;196m[ERROR]\e[0m Failed to create initial Git commit."

--- a/install.sh
+++ b/install.sh
@@ -180,66 +180,93 @@ echo -e "\e[38;5;72m[INFO]\e[0m Creating pyproject.toml for Ruff configuration..
 install -m 644 /dev/null "${project_path}/pyproject.toml"
 cat > "${project_path}/pyproject.toml" << EOL
 [tool.ruff]
-src = ["${project_name}"]
-line-length = 88
-target-version = "py312"
+src = ["${project_name}"]                   # Project root directory
+line-length = 88                            # Maximum line length
+target-version = "py312"                    # Target Python version
 exclude = [
-    "${project_name}/config/asgi.py",
-    "${project_name}/config/wsgi.py",
-    "${project_name}/manage.py",
-    "**/migrations/*",
-    "**/templates/**/*.html",
-    "**/static/**/*",
-    "**/*.j2",
-    "**/__pycache__/",
-    "**/*.pyc",
+    "${project_name}/config/asgi.py",       # Exclude ASGI configuration
+    "${project_name}/config/wsgi.py",       # Exclude WSGI configuration
+    "${project_name}/manage.py",            # Exclude manage.py
+    "${project_name}/**/migrations/*",      # Exclude migrations
+    "${project_name}/**/tests/*",           # Exclude tests
+    "${project_name}/static/**/*",          # Exclude static files
+    "**/__pycache__/",                      # Exclude Python cache
+    "**/*.pyc",                             # Exclude compiled Python files
+    "**/*.j2",                              # Exclude Jinja2 templates
 ]
 
 [tool.ruff.lint]
 select = [
-    "E", "F", "W", "I", "DJ", "UP", "RUF",
-    "C90", "N", "S", "B", "A", "COM", "C4", "DTZ", "T10", "PERF"
+    "E", "F", "W", "I",                     # PEP 8, Pyflakes, isort
+    "DJ", "UP", "RUF",                      # Django, pyupgrade, Ruff-specific
+    "D", "C90", "N",                        # Docstring, complexity, PEP 8 naming
+    "S", "B", "A",                          # Security, bugbear, builtins
+    "C4",                                   # Comprehensions
+    "DTZ",                                  # Datetime
+    "T10", "PERF"                           # Debug calls, performance
 ]
-ignore = ["E501", "S101", "COM812"]
-# Django-specific settings integrated here
-extend-select = ["DJ"]  # Enable Django-specific rules
+ignore = [
+    "E501",                                 # Line too long
+    "D100",                                 # Missing module docstring
+    "D104",                                 # Missing package docstring
+    "D212",                                 # Conflicts with D211
+    "D203",                                 # Conflicts with D211
+    "S101"                                  # Assert usage
+]
+fixable = [
+    "E", "F", "W", "I", "UP", "RUF", "C4", "T10"  # Rules that Ruff can auto-fix
+]
 
 [tool.ruff.lint.per-file-ignores]
-"${project_name}/config/settings/local.py" = ["F403", "F405"]
-"${project_name}/config/settings/production.py" = ["F403", "F405"]
+"${project_name}/config/settings/local.py" = ["F403", "F405"]       # Ignore * imports
+"${project_name}/config/settings/production.py" = ["F403", "F405"]  # Ignore * imports
 
 [tool.ruff.lint.isort]
-known-first-party = ["${project_name}"]
+known-first-party = ["${project_name}"]  # Custom modules
+
+[tool.ruff.lint.pydocstyle]
+convention = "google"                       # Docstring style
 
 [tool.ruff.format]
-quote-style = "single"
-indent-style = "space"
+quote-style = "single"                      # Single quotes
+indent-style = "space"                      # Space indentation
 
 [tool.pytest.ini_options]
 minversion = "6.0"
-addopts = "--ds=${project_name}.config.settings.test --reuse-db --import-mode=importlib"
+addopts = "--ds=${project_name}.config.settings.test --import-mode=importlib"
 python_files = ["tests.py", "test_*.py"]
+DJANGO_SETTINGS_MODULE = "${project_name}.config.settings.test"  # Test settings
 
 [tool.coverage.run]
-include = ["${project_name}/**"]
-omit = ["*/migrations/*", "*/tests/*"]
+source = ["${project_name}"]  # Coverage for the project directory
+omit = [
+    "${project_name}/**/migrations/*",      # Exclude migrations
+    "${project_name}/**/tests/*",           # Exclude tests
+    "${project_name}/config/settings/*"     # Exclude settings
+]
 plugins = ["django_coverage_plugin"]
 
 [tool.mypy]
 python_version = "3.12"
 check_untyped_defs = true
-ignore_missing_imports = true
 warn_unused_ignores = true
 warn_redundant_casts = true
 warn_unused_configs = true
 plugins = ["mypy_django_plugin.main"]
+disallow_untyped_defs = true  # Strict type checking
 
-[[tool.mypy.overrides]]
-module = "*.migrations.*"
+[tool.mypy.overrides]
+module = [
+    "${project_name}.*.migrations.*",       # Ignore migrations
+    "allauth.*"                             # Ignore django-allauth
+]
 ignore_errors = true
 
 [tool.django-stubs]
-django_settings_module = "${project_name}.config.settings"
+django_settings_module = "${project_name}.config.settings"  # Settings for django-stubs
+
+[tool.ruff.lint.mccabe]
+max-complexity = 12                         # Cyclomatic complexity limit
 EOL
 
 # Create .djlintrc for djlint configuration


### PR DESCRIPTION
Removed [tool.coverage.run] section from pyproject.toml to eliminate duplicated coverage configuration, as settings are now managed in .coveragerc. This also removes the unused django_coverage_plugin reference.