### PR TITLE
Add environment variable support for tools scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,8 +335,8 @@ The project uses `uv` for fast and reliable dependency management, offering sign
 - **`gunicorn.sh`**:
 
   - Runs Gunicorn manually for debugging or development without Systemd.
-  - Supports the `--project` parameter to specify the project name (e.g., `--project nowknow`). If not provided, it prompts for the project name and path.
-  - If a corresponding environment variable (e.g., `NOWKNOW_PATH`) is set, it uses that path; otherwise, it prompts for the path.
+  - Supports the `--project` parameter to specify the project name (e.g., `--project <project_name>`). If not provided, it prompts for the project name and path.
+  - If a corresponding environment variable (e.g., `PROJECT_NAME_PATH`) is set, it uses that path; otherwise, it prompts for the path.
   - Usage:
 
     ```zsh
@@ -352,8 +352,8 @@ The project uses `uv` for fast and reliable dependency management, offering sign
 - **`runserver.sh`**:
 
   - Starts the Django development server for quick testing.
-  - Supports the `--project` parameter to specify the project name (e.g., `--project nowknow`). If not provided, it prompts for the project name and path.
-  - If a corresponding environment variable (e.g., `NOWKNOW_PATH`) is set, it uses that path; otherwise, it prompts for the path.
+  - Supports the `--project` parameter to specify the project name (e.g., `--project <project_name>`). If not provided, it prompts for the project name and path.
+  - If a corresponding environment variable (e.g., `PROJECT_NAME_PATH`) is set, it uses that path; otherwise, it prompts for the path.
   - Usage:
 
     ```zsh
@@ -368,14 +368,14 @@ The project uses `uv` for fast and reliable dependency management, offering sign
 
 - **Setting up environment variables for helper scripts**:
 
-  To streamline usage of `gunicorn.sh` and `runserver.sh`, you can set an environment variable for your project's path. For example, to set the path for a project named `nowknow`:
+  To streamline usage of `gunicorn.sh` and `runserver.sh`, you can set an environment variable for your project's path. For example, to set the path for a project named `<project_name>`:
 
   ```zsh
-  echo 'export NOWKNOW_PATH="$HOME/projects/nowknowApp"' >> ~/.zshrc
+  echo 'export PROJECT_NAME_PATH="$HOME/projects/<project_directory>"' >> ~/.zshrc
   source ~/.zshrc
   ```
 
-  This ensures the `NOWKNOW_PATH` variable is available in every new terminal session, allowing the scripts to automatically use the specified path when `--project nowknow` is provided. Replace `nowknowApp` with your actual project directory name.
+  This ensures the `PROJECT_NAME_PATH` variable is available in every new terminal session, allowing the scripts to automatically use the specified path when `--project <project_name>` is provided. Replace `<project_directory>` with your actual project directory name.
 
 ## Docker Deployment
 

--- a/README.md
+++ b/README.md
@@ -335,7 +335,15 @@ The project uses `uv` for fast and reliable dependency management, offering sign
 - **`gunicorn.sh`**:
 
   - Runs Gunicorn manually for debugging or development without Systemd.
+  - Supports the `--project` parameter to specify the project name (e.g., `--project nowknow`). If not provided, it prompts for the project name and path.
+  - If a corresponding environment variable (e.g., `NOWKNOW_PATH`) is set, it uses that path; otherwise, it prompts for the path.
   - Usage:
+
+    ```zsh
+    ./gunicorn.sh --project nowknow
+    ```
+
+    Or without parameters:
 
     ```zsh
     ./gunicorn.sh
@@ -344,11 +352,30 @@ The project uses `uv` for fast and reliable dependency management, offering sign
 - **`runserver.sh`**:
 
   - Starts the Django development server for quick testing.
+  - Supports the `--project` parameter to specify the project name (e.g., `--project nowknow`). If not provided, it prompts for the project name and path.
+  - If a corresponding environment variable (e.g., `NOWKNOW_PATH`) is set, it uses that path; otherwise, it prompts for the path.
   - Usage:
+
+    ```zsh
+    ./runserver.sh --project nowknow
+    ```
+
+    Or without parameters:
 
     ```zsh
     ./runserver.sh
     ```
+
+- **Setting up environment variables for helper scripts**:
+
+  To streamline usage of `gunicorn.sh` and `runserver.sh`, you can set an environment variable for your project's path. For example, to set the path for a project named `nowknow`:
+
+  ```zsh
+  echo 'export NOWKNOW_PATH="$HOME/projects/nowknowApp"' >> ~/.zshrc
+  source ~/.zshrc
+  ```
+
+  This ensures the `NOWKNOW_PATH` variable is available in every new terminal session, allowing the scripts to automatically use the specified path when `--project nowknow` is provided. Replace `nowknowApp` with your actual project directory name.
 
 ## Docker Deployment
 

--- a/install.sh
+++ b/install.sh
@@ -128,15 +128,18 @@ psycopg[c]>=3.2.6               # https://github.com/psycopg/psycopg (C bindings
 # Configuration
 django-environ>=0.12.0          # https://github.com/joke2k/django-environ
 
+# HTTP requests
+requests>=2.31.0                # https://github.com/psf/requests
+
 # Deployment
 gunicorn>=23.0.0                # https://github.com/benoitc/gunicorn
 
 # Templating
 jinja2>=3.1.2                   # https://github.com/pallets/jinja
+django-jinja>=2.10.3            # https://github.com/niwinz/django-jinja
 
-# Authentication & Security
+# Authentication
 django-allauth[mfa]>=65.4.1     # https://github.com/pennersr/django-allauth (MFA support)
-django-recaptcha==4.1.0         # https://github.com/torchbox/django-recaptcha
 EOL
 
 cat > "${project_path}/${project_name}/requirements/local.in" << EOL
@@ -1274,7 +1277,7 @@ LOGGING = {
             'stream': sys.stdout,
         },
         'file': {
-            'level': 'DEBUG',
+            'level': 'INFO',
             'class': 'logging.FileHandler',
             'filename': BASE_DIR / 'log/django.log',
             'formatter': 'verbose',

--- a/tools/gunicorn.sh
+++ b/tools/gunicorn.sh
@@ -1,15 +1,55 @@
 #!/bin/bash
 set -e
 
-read -e -p "Project name: " project_name
-if [[ -z "${project_name}" ]]; then
-    echo -e "\e[38;5;196m[ERROR]\e[0m Project name is required."
+# Function to display usage information
+usage() {
+    echo "Usage: $0 [--project PROJECT_NAME]"
+    echo "  --project  Project name. If not specified, it will be prompted from the user."
     exit 1
+}
+
+# Parse command-line parameters
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        --project)
+            if [[ -n "$2" && "$2" != --* ]]; then
+                project_name="$2"
+                shift 2
+            else
+                echo -e "\e[38;5;196m[ERROR]\e[0m The --project parameter requires a value."
+                usage
+            fi
+            ;;
+        *)
+            echo -e "\e[38;5;196m[ERROR]\e[0m Unknown parameter: $1"
+            usage
+            ;;
+    esac
+done
+
+# If project_name is not specified, prompt the user
+if [[ -z "$project_name" ]]; then
+    read -e -p "Project name: " project_name
+    if [[ -z "${project_name}" ]]; then
+        echo -e "\e[38;5;196m[ERROR]\e[0m Project name is required."
+        exit 1
+    fi
 fi
 
-read -e -p "Project path: " project_path
-project_path="${project_path/#\~/$HOME}"
-project_path=$(realpath -m "${project_path}")
+# Check for project path in environment variable or prompt the user
+project_path_var="${project_name^^}_PATH"
+project_path="${!project_path_var}"
+
+# Expand ~ in project_path if it comes from environment variable
+if [[ -n "$project_path" ]]; then
+    project_path="${project_path/#\~/$HOME}"
+fi
+
+if [[ -z "$project_path" ]]; then
+    read -e -p "Project path: " project_path
+    project_path="${project_path/#\~/$HOME}"
+    project_path=$(realpath -m "${project_path}")
+fi
 
 if [[ -z "${project_path}" ]]; then
     echo -e "\e[38;5;196m[ERROR]\e[0m Project path is required."

--- a/tools/runserver.sh
+++ b/tools/runserver.sh
@@ -1,15 +1,54 @@
 #!/bin/bash
 set -e
 
-read -e -p "Project name: " project_name
-if [[ -z "${project_name}" ]]; then
-    echo -e "\e[38;5;196m[ERROR]\e[0m Project name is required."
+usage() {
+    echo "Usage: $0 [--project PROJECT_NAME]"
+    echo "  --project  Project name. If not specified, it will be prompted from the user."
     exit 1
+}
+
+# Parse command-line parameters
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        --project)
+            if [[ -n "$2" && "$2" != --* ]]; then
+                project_name="$2"
+                shift 2
+            else
+                echo -e "\e[38;5;196m[ERROR]\e[0m The --project parameter requires a value."
+                usage
+            fi
+            ;;
+        *)
+            echo -e "\e[38;5;196m[ERROR]\e[0m Unknown parameter: $1"
+            usage
+            ;;
+    esac
+done
+
+# If project_name is not specified, prompt the user
+if [[ -z "$project_name" ]]; then
+    read -e -p "Project name: " project_name
+    if [[ -z "${project_name}" ]]; then
+        echo -e "\e[38;5;196m[ERROR]\e[0m Project name is required."
+        exit 1
+    fi
 fi
 
-read -e -p "Project path: " project_path
-project_path="${project_path/#\~/$HOME}"
-project_path=$(realpath -m "${project_path}")
+# Check for project path in environment variable or prompt the user
+project_path_var="${project_name^^}_PATH"
+project_path="${!project_path_var}"
+
+if [[ -n "$project_path" ]]; then
+    project_path="${project_path/#\~/$HOME}"
+fi
+
+
+if [[ -z "$project_path" ]]; then
+    read -e -p "Project path: " project_path
+    project_path="${project_path/#\~/$HOME}"
+    project_path=$(realpath -m "${project_path}")
+fi
 
 if [[ -z "${project_path}" ]]; then
     echo -e "\e[38;5;196m[ERROR]\e[0m Project path is required."


### PR DESCRIPTION
This PR adds support for environment variables in gunicorn.sh and runserver.sh, allowing project paths to be specified via variables like PROJECT_NAME_PATH. The scripts now accept a --project parameter and fall back to user prompts if variables or parameters are not provided.